### PR TITLE
Check if request has been reopened and use for checking elapsed time

### DIFF
--- a/lang/en/local_extension.php
+++ b/lang/en/local_extension.php
@@ -315,7 +315,7 @@ $string['table_header_rule_priority'] = 'Priority';
 $string['table_header_statushead'] = 'Status';
 $string['table_header_statusrow'] = '<a href="{$a}">Click to view request status</a>';
 $string['table_header_username'] = 'Requesting User';
-$string['task_process'] = 'Process Tiggers / Rules';
+$string['task_process'] = 'Process Triggers / Rules';
 $string['task_email_digest'] = 'E-mail Digest Processing';
 $string['template_notify_content'] = '{{course}} => Course full name<br />
 {{module}} => Course module name<br />


### PR DESCRIPTION
For jira 1488. 

The way I understand this one is like this. There is a check for elapsed length, the days since the request is originally opened, and the current time.

The problem is that it should be checking this elapsed length from the reopened date if one exists. That's why there are emails being sent, because there are many days elapsed between the original request date and the current time, so it thinks it is time for a reminder email. Really, the elapsed length should be zero days just after the request is reopened.

This code will always use the reopened date if there is one rather than the original date. I can't think of a reason that it should go back to using the original date for this check but maybe that could be something to consider and add to this code. 




