### PR TITLE
MOODLE-1630: Student unable to view assignments

### DIFF
--- a/classes/utility.php
+++ b/classes/utility.php
@@ -426,11 +426,14 @@ class utility {
      * @return array
      */
     public static function find_module_requests($courseid, $moduleid) {
-        global $USER;
+        global $USER, $DB;
 
-        $requests = self::cache_get_requests($USER->id);
+        $conditions = array('cmid' => $moduleid, 'userid' => $USER->id);
+        $record = $DB->get_record('local_extension_cm', $conditions, 'request');
 
-        foreach ($requests as $request) {
+        if (!empty($record)) {
+            $request = self::cache_get_request($record->request);
+
             foreach ($request->cms as $cm) {
                 if ($courseid == $cm->get_courseid() && $moduleid == $cm->cmid) {
                     return [$request, $cm];


### PR DESCRIPTION
Loading and caching every request a student has takes up a lot of memory if a student has a lot of requests. This leads to memory errors.

To fix this we only load and cache the single request (if it exsits) for the module we are viewing to avoid memory spikes.