### PR TITLE
Search that needle in haystack assertion for string

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -37,6 +37,11 @@ defined('MOODLE_INTERNAL') || die;
 function local_extension_extend_navigation_course(\navigation_node $navigation, \stdClass $course, \context $context) {
     global $PAGE, $USER;
 
+    // Only add this settings item on non-site course pages.
+    if (!$PAGE->course or $PAGE->course->id == 1) {
+        return;
+    }
+
     if (!is_enrolled($PAGE->context, $USER->id)) {
         return;
     }

--- a/tests/phpunit/message/email_test.php
+++ b/tests/phpunit/message/email_test.php
@@ -70,7 +70,7 @@ class local_extension_email_test extends extension_testcase {
 
         self::assertCount(2, $sink->get_messages());
         foreach ($sink->get_messages() as $key => $message) {
-            self::assertContains('XYZ_TEST', $message->subject, "Message #[{$key}]");
+            self::assertStringContainsString('XYZ_TEST', $message->subject, "Message #[{$key}]");
         }
     }
 }


### PR DESCRIPTION
Fixes the units test:
```
root@d90769db92e5:/var/www/he# vendor/bin/phpunit --testsuite local_extension_testsuite

Moodle 4.1.3+ (Build: 20230526), 392e0fe6ea65940786e2cb5e4f6f41978f81e936
Php: 8.0.28, pgsql: 14.0 (Debian 14.0-1.pgdg110+1), OS: Linux 5.19.0-43-generic x86_64
PHPUnit 9.5.27 by Sebastian Bergmann and contributors.

..E................................................               51 / 51 (100%)

Time: 00:07.176, Memory: 105.00 MB

There was 1 error:

1) local_extension_email_test::test_the_subject_has_the_course_shortname
TypeError: PHPUnit\Framework\Assert::assertContains(): Argument #2 ($haystack) must be of type iterable, string given, called in /var/www/he/local/extension/tests/phpunit/message/email_test.php on line 73

/var/www/he/local/extension/tests/phpunit/message/email_test.php:73
/var/www/he/lib/phpunit/classes/advanced_testcase.php:80

ERRORS!
Tests: 51, Assertions: 120, Errors: 1.
```

Applying the change
```
root@d90769db92e5:/var/www/he# vendor/bin/phpunit --testsuite local_extension_testsuite

Moodle 4.1.3+ (Build: 20230526), 392e0fe6ea65940786e2cb5e4f6f41978f81e936
Php: 8.0.28, pgsql: 14.0 (Debian 14.0-1.pgdg110+1), OS: Linux 5.19.0-43-generic x86_64
PHPUnit 9.5.27 by Sebastian Bergmann and contributors.

...................................................               51 / 51 (100%)

Time: 00:05.693, Memory: 105.00 MB

OK (51 tests, 122 assertions)
```