### PR TITLE
Resolve unit test failure

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -66,7 +66,7 @@ if ($hassiteconfig) {
 
     $settings->add(new admin_settings_coursecat_select('local_extension/defaultcategory',
         new lang_string('defaultcategory',         'local_extension'),
-        new lang_string('defaultcategoryhelp',     'local_extension'), 0));
+        new lang_string('defaultcategoryhelp',     'local_extension'), 1));
 
     $settings->add(new admin_setting_configcheckbox('local_extension/emaildisable',
         new lang_string('emaildisable',             'local_extension'),


### PR DESCRIPTION
The core unit test adminlib_test::test_admin_output_new_settings_by_page tests that extra settings in additional plugins are configured with default plugins. If there is no default value, then a workaround must be created into their db/install.php for PHPUnit and Behat tests.

This pull requests makes sure the all the settings have a default value, resolving the unit test failure. 