### PR TITLE
Check that is_enrolled of course context, not page context

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -51,7 +51,7 @@ function local_extension_extend_navigation_course(\navigation_node $navigation, 
         $label = get_string('nav_index', 'local_extension');
     }
 
-    if (!is_enrolled($PAGE->context, $USER->id) && !$hascap) {
+    if (!is_enrolled($context, $USER->id) && !$hascap) {
         return;
     }
 


### PR DESCRIPTION
When editing a user during course context the page raised a coding exception. 

The $PAGE->context is user, when expected course context. The $context parameter is of course context. 

To replicate:
1. Go to a course
2. Click the Participants tab
3. Right-click on any user in the list and open in new tab
4. When their user profile opens, click Edit profile
5. The error appears