### PR TITLE
OS-1597: fix potential course_get_course_for_user_id undefined function

### DIFF
--- a/classes/utility.php
+++ b/classes/utility.php
@@ -252,6 +252,9 @@ class utility {
             }
 
             $handler = extension::get_enabled_request()[$cm->modname];
+
+            // We want to cache the cm record and not the full cm_info object.
+            $cm = $cm->get_course_module_record();
         }
 
         $data = new mod_data();

--- a/status.php
+++ b/status.php
@@ -29,7 +29,6 @@ use local_extension\state;
 use local_extension\utility;
 
 require_once(__DIR__ . '/../../config.php');
-require_once($CFG->dirroot . '/course/lib.php');
 
 global $PAGE, $USER;
 


### PR DESCRIPTION
The issue that needs to be fixed is that getting the cm_info object includes the course lib file that contains the undefined function, however in certain scenarios we cache the full cm_info object so after it is cached we no longer fetch cm_info and this later creates an issue due to the missing course lib.

The scenario that happens is when there is no calendar event, I'm not sure how exactly the calendar event is removed for a user, but a quick test to replicate that scenario is to set $allevents to empty around here https://github.com/central-queensland-uni/moodle-local_extension/blob/ee25588de556344d2589ccf091a25bea8bd13d7b/classes/utility.php#L86

Ensure you clear all MUC cache when testing since the issue arises after the cache has been set.