### PR TITLE
OS-1597 fix eventless requests

### DIFF
--- a/classes/utility.php
+++ b/classes/utility.php
@@ -264,6 +264,18 @@ class utility {
         $data->course = $course;
         $data->handler = $handler;
 
+        if (is_object($data->event) && !isset($data->event->modulename)) {
+            $data->event->modulename = $cm->modname;
+            $data->event->instance = $cm->instance;
+
+            $timestart = null;
+            if (!is_null($data->handler)) {
+                $timestart = $data->handler->get_due_date($data);
+            }
+
+            $data->event->timestart = $timestart;
+        }
+
         return $data;
     }
 

--- a/mod/assign/classes/request.php
+++ b/mod/assign/classes/request.php
@@ -162,8 +162,9 @@ class request extends \local_extension\base_request {
     }
 
     public function get_due_date($mod) {
-        if (is_null($mod->event)) {
-            return null;
+        if (is_null($mod->event) || !isset($mod->event->timestart)) {
+            [$course, $cm] = get_course_and_cm_from_cmid($mod->cm->id);
+            return $cm->customdata['duedate'];
         }
         return $mod->event->timestart;
     }

--- a/mod/quiz/classes/request.php
+++ b/mod/quiz/classes/request.php
@@ -127,6 +127,12 @@ class request extends \local_extension\base_request {
     }
 
     public function get_due_date($mod) {
+        global $DB;
+
+        if (is_null($mod->event) || !isset($mod->event->timestart)) {
+            $quiz = $DB->get_record('quiz', ['id' => $mod->cm->instance], 'timeclose');
+            return $quiz->timeclose;
+        }
         return $mod->event->timeclose;
     }
 

--- a/renderer.php
+++ b/renderer.php
@@ -224,7 +224,7 @@ class local_extension_renderer extends plugin_renderer_base {
             $user = core_user::get_user($file->get_userid());
 
             $obj = new stdClass();
-            $obj->file = $this->output->pix_icon(file_file_icon($file, 16), get_mimetype_description($file)) .
+            $obj->file = $this->output->pix_icon(file_file_icon($file), get_mimetype_description($file)) .
                 ' ' . html_writer::link($fileurl, $f->get_filename());
             $obj->user = fullname($user);
             $obj->date = userdate($file->get_timecreated());


### PR DESCRIPTION
This fixes issues where a request has been put in but somehow the event has gone missing after it. Issues inlcude the activity link being broken and being unable to approve the request.

To replicate issues;
1. Create a request on an assignment
2. Delete the related mdl_event record for that assignment
3. Clear the cache so it rebuilds with the event missing
4. Check the status of the request, the link to the assignment should be broken if clicked on
5. Try to approve the request, you will get errors thrown at you

There is also a tiny deprecation fix here for a file_file_icon call.