### PR TITLE
OS-1657: Resolve hist state not backing up

### DIFF
--- a/backup/moodle2/backup_local_extension_plugin.class.php
+++ b/backup/moodle2/backup_local_extension_plugin.class.php
@@ -131,7 +131,7 @@ class backup_local_extension_plugin extends backup_plugin {
         $request->add_child($comments);
         $request->add_child($cm);
         $request->add_child($histfiles);
-        $cm->add_child($histstates);
+        $request->add_child($histstates);
         $cm->add_child($histtriggers);
         $cm->add_child($subscriptions);
 
@@ -173,6 +173,8 @@ class backup_local_extension_plugin extends backup_plugin {
         // Define the sources of the children of $request.
         $comment->set_source_table('local_extension_comment',
             ['request' => '../../id']);
+        $histstate->set_source_table('local_extension_hist_state',
+            ['requestid' => '../../id']);
         $cm->set_source_table('local_extension_cm',
             ['request' => backup::VAR_PARENTID]);
 
@@ -185,8 +187,6 @@ class backup_local_extension_plugin extends backup_plugin {
             ['request' => '../../id']);
 
         // Define the sources of the children of $cm.
-        $histstate->set_source_table('local_extension_hist_state',
-            ['requestid' => '../../../id', 'localcmid' => '../../id']);
         $histtrigger->set_source_table('local_extension_hist_trig',
             ['requestid' => '../../../id', 'localcmid' => '../../id']);
         $subscription->set_source_table('local_extension_subscription',

--- a/backup/moodle2/restore_local_extension_plugin.class.php
+++ b/backup/moodle2/restore_local_extension_plugin.class.php
@@ -39,7 +39,7 @@ class restore_local_extension_plugin extends restore_local_plugin {
         $paths[] = new restore_path_element('comment', $this->get_pathfor('requests/request/comments/comment'));
         $paths[] = new restore_path_element('cm', $this->get_pathfor('requests/request/cm'));
         $paths[] = new restore_path_element('hist_file', $this->get_pathfor('requests/request/hist_files/hist_file'));
-        $paths[] = new restore_path_element('hist_state', $this->get_pathfor('requests/request/cm/hist_states/hist_state'));
+        $paths[] = new restore_path_element('hist_state', $this->get_pathfor('requests/request/hist_states/hist_state'));
         $paths[] = new restore_path_element('subscription', $this->get_pathfor('requests/request/cm/subscriptions/subscription'));
         $paths[] = new restore_path_element('hist_trig', $this->get_pathfor('requests/request/cm/hist_trigs/hist_trig'));
 
@@ -218,7 +218,7 @@ class restore_local_extension_plugin extends restore_local_plugin {
 
         $data = (object)$data;
         $data->requestid = $this->get_new_parentid('request');
-        $data->localcmid = $this->get_new_parentid('cm');
+        $data->localcmid =  $this->task->get_moduleid();
         $data->userid = $this->get_mappingid('user', $data->userid);
 
         $DB->insert_record('local_extension_hist_state', $data);


### PR DESCRIPTION
**Test instructions**:
1. Open local/extension/rules/manage.php
2. Add a new rule on Assignment
3. Enter a name, leave the rest default
4. Add a course with;
    - One assignment that has a due date within this week, I chose upcoming Friday.
    - One enrolled student
5. In a private window, login as the student.
6. Open the created course
7. Click "Request Extension" from the course navigation. 
8. Click Request an Extension and select the Assignment, complete the form.
9. Open the Extension request.
10. Click Cancel request.
11. Click "Confirm state change and return to comment stream".
12. Click "Reopen request".
13. Click "Confirm state change and return to comment stream".
14. Observe that the Extension History has 3 statuses "New", "Cancelled" and "Reopened". 
15. As the Admin, backup the course using the default Backup settings.
16. Restore the course as the option "Restore as a new course".
17. Open local/extension/index.php and observe a extension has appeared for the restored course.
18. Open the restored request and observe the 3 statuses in the extension history.

**EDIT:** Added more details to the instructions.