### PR TITLE
OS-1597: add required change reverted from backup/restore changes

### DIFF
--- a/classes/utility.php
+++ b/classes/utility.php
@@ -244,7 +244,7 @@ class utility {
                                            'instance'   => $cm->instance,
                                        ],
                                        'id ASC');
-            $event = (count($events) > 0) ? reset($events) : null;
+            $event = (count($events) > 0) ? reset($events) : new \stdClass();
 
             // Get the assignment name from the cm object rather than the events table
             if (is_object($event)) {


### PR DESCRIPTION
This change was done as part of  https://github.com/central-queensland-uni/moodle-local_extension/commit/ef0ff9d87e2c11d8390b236443ef031a42f4500b but then reverted because we do not want the full change in production. I've picked out this change because recent changes rely on it, hence why the local_extension\utility_test::test_create_request_mod_data unit test is failing right now.